### PR TITLE
Upgrade to gleam_http 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- Upgraded `gleam_http` to v3.0.0. (#3)

--- a/gleam.toml
+++ b/gleam.toml
@@ -6,11 +6,11 @@ repository = { type = "github", user = "lpil", repo = "nerf" }
 links = [{ title = "Website", href = "https://gleam.run" }]
 
 [dependencies]
-gleam_stdlib = "~> 0.18"
+gleam_stdlib = "~> 0.2"
 gun = "> 1.3.0 and < 3.0.0"
-gleam_http = "~> 2.1"
-gleam_erlang = "~> 0.5"
+gleam_http = "~> 3.0"
+gleam_erlang = "~> 0.9"
 certifi = "~> 2.8"
 
 [dev-dependencies]
-gleeunit = "~> 0.5"
+gleeunit = "~> 0.6"

--- a/manifest.toml
+++ b/manifest.toml
@@ -4,17 +4,17 @@
 packages = [
   { name = "certifi", version = "2.8.0", build_tools = ["rebar3"], requirements = [], otp_app = "certifi", source = "hex", outer_checksum = "6AC7EFC1C6F8600B08D625292D4BBF584E14847CE1B6B5C44D983D273E1097EA" },
   { name = "cowlib", version = "2.7.3", build_tools = ["rebar3"], requirements = [], otp_app = "cowlib", source = "hex", outer_checksum = "1E1A3D176D52DAEBBECBBCDFD27C27726076567905C2A9D7398C54DA9D225761" },
-  { name = "gleam_erlang", version = "0.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "6DC8D506127BF332A48DBE1A286ACAAA0F2C7BF84B33BD9E6F3A8002EC9F649C" },
-  { name = "gleam_http", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "C2DF02A2BD551B590D92ADA90A67CDEE60EB4BAD48B5EE10A9AB4CE180CBCE36" },
-  { name = "gleam_stdlib", version = "0.18.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "2938F996BBB25D75E973226846CDDFA33AB5590AFC8A9D043A356EA85272510D" },
-  { name = "gleeunit", version = "0.5.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7FA7477D930178C1E59519DBDB5E086BE3A6B65F015B67DA94D30A323062154" },
+  { name = "gleam_erlang", version = "0.9.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "15D0B66DA08D63C16EDDF32A70F6EB49E44DC83DB0370B7A45F1E954F8A23174" },
+  { name = "gleam_http", version = "3.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "FB65B42C7AF4C14F1DC0AD9A3ABCE50E9486D3F8D0A42C9E52A2B8BD651739DF" },
+  { name = "gleam_stdlib", version = "0.20.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "E5715F0CDCB3AB1BB73C6C35E46DA223997F680550E17CE46BC88B710E061CCE" },
+  { name = "gleeunit", version = "0.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "5BF486C3E135B7F5ED8C054925FC48E5B2C79016A39F416FD8CF2E860520EE55" },
   { name = "gun", version = "1.3.3", build_tools = ["rebar3"], requirements = ["cowlib"], otp_app = "gun", source = "hex", outer_checksum = "3106CE167F9C9723F849E4FB54EA4A4D814E3996AE243A1C828B256E749041E0" },
 ]
 
 [requirements]
 certifi = "~> 2.8"
-gleam_erlang = "~> 0.5"
-gleam_http = "~> 2.1"
-gleam_stdlib = "~> 0.18"
-gleeunit = "~> 0.5"
+gleam_erlang = "~> 0.9"
+gleam_http = "~> 3.0"
+gleam_stdlib = "~> 0.2"
+gleeunit = "~> 0.6"
 gun = "> 1.3.0 and < 3.0.0"

--- a/src/nerf/websocket.gleam
+++ b/src/nerf/websocket.gleam
@@ -1,4 +1,3 @@
-import gleam/uri.{Uri}
 import gleam/http.{Header}
 import gleam/dynamic.{Dynamic}
 import gleam/result


### PR DESCRIPTION
This allows this library to be used with others that expect the HTTP 3.0 API