### PR TITLE
Duplicated import

### DIFF
--- a/src/nerf/websocket.gleam
+++ b/src/nerf/websocket.gleam
@@ -3,7 +3,6 @@ import gleam/dynamic.{Dynamic}
 import gleam/result
 import gleam/string_builder.{StringBuilder}
 import gleam/bit_builder.{BitBuilder}
-import gleam/result
 import nerf/gun.{ConnectionPid, StreamReference}
 
 pub opaque type Connection {


### PR DESCRIPTION
```
  Compiling nerf
error: Duplicate import
  ┌─ build/packages/nerf/src/nerf/websocket.gleam:3:8
  │
3 │ import gleam/result
  │        ^^^^^^^^^^^^ First imported here
  ·
6 │ import gleam/result
  │        ^^^^^^^^^^^^ Reimported here

result has been imported multiple times.
Names in a Gleam module must be unique so one will need to be renamed.
```

Removing the line fixes the issue.