### PR TITLE
Added some options for connect

### DIFF
--- a/src/nerf/gun.gleam
+++ b/src/nerf/gun.gleam
@@ -19,11 +19,7 @@ pub fn open(
   open_erl(charlist.from_string(host), port, opts_map)
 }
 
-pub external fn open_erl(
-  Charlist,
-  Int,
-  Dynamic,
-) -> Result(ConnectionPid, Dynamic) =
+external fn open_erl(Charlist, Int, Dynamic) -> Result(ConnectionPid, Dynamic) =
   "gun" "open"
 
 pub external fn await_up(ConnectionPid) -> Result(Dynamic, Dynamic) =

--- a/src/nerf/gun.gleam
+++ b/src/nerf/gun.gleam
@@ -11,11 +11,19 @@ pub external type StreamReference
 
 pub external type ConnectionPid
 
-pub fn open(host: String, port: Int) -> Result(ConnectionPid, Dynamic) {
-  open_erl(charlist.from_string(host), port)
+pub fn open(
+  host: String,
+  port: Int,
+  opts_map: Dynamic,
+) -> Result(ConnectionPid, Dynamic) {
+  open_erl(charlist.from_string(host), port, opts_map)
 }
 
-pub external fn open_erl(Charlist, Int) -> Result(ConnectionPid, Dynamic) =
+pub external fn open_erl(
+  Charlist,
+  Int,
+  Dynamic,
+) -> Result(ConnectionPid, Dynamic) =
   "gun" "open"
 
 pub external fn await_up(ConnectionPid) -> Result(Dynamic, Dynamic) =

--- a/src/nerf/gun.gleam
+++ b/src/nerf/gun.gleam
@@ -6,6 +6,7 @@ import gleam/erlang/charlist.{Charlist}
 import gleam/dynamic.{Dynamic}
 import gleam/string_builder.{StringBuilder}
 import gleam/bit_builder.{BitBuilder}
+import nerf/opts.{ConnectionOpts}
 
 pub external type StreamReference
 
@@ -14,8 +15,13 @@ pub external type ConnectionPid
 pub fn open(
   host: String,
   port: Int,
-  opts_map: Dynamic,
+  opts: ConnectionOpts,
 ) -> Result(ConnectionPid, Dynamic) {
+  let opts_map =
+    opts
+    |> opts.to_gun_format
+    |> opts.map_from_list
+
   open_erl(charlist.from_string(host), port, opts_map)
 }
 

--- a/src/nerf/opts.gleam
+++ b/src/nerf/opts.gleam
@@ -1,0 +1,45 @@
+import gleam/erlang/atom.{Atom}
+
+pub type TlsVerify {
+  VerifyNone
+  VerifyPeer
+}
+
+pub type ConnectionTransport {
+  Tls(verify: TlsVerify)
+  Tcp
+}
+
+pub type ConnectionOpts {
+  ConnectionOpts(transport: ConnectionTransport)
+}
+
+//
+
+pub type GunConnectionOptsTransportOpt {
+  Verify(Atom)
+}
+
+pub type GunConnectionOpt {
+  Transport(Atom)
+  TransportOpts(List(GunConnectionOptsTransportOpt))
+}
+
+pub fn to_gun_format(conn_opts: ConnectionOpts) -> List(GunConnectionOpt) {
+  let tcp = atom.create_from_string("tcp")
+  let tls = atom.create_from_string("tls")
+  // tls transport opts
+  let verify_none = atom.create_from_string("verify_none")
+
+  case conn_opts {
+    ConnectionOpts(transport: Tcp) -> [Transport(tcp)]
+    ConnectionOpts(transport: Tls(verify: VerifyPeer)) -> [Transport(tls)]
+    ConnectionOpts(transport: Tls(verify: VerifyNone)) -> [
+      Transport(tls),
+      TransportOpts([Verify(verify_none)]),
+    ]
+  }
+}
+
+pub external fn map_from_list(list: List(a)) -> m =
+  "maps" "from_list"

--- a/src/nerf/websocket.gleam
+++ b/src/nerf/websocket.gleam
@@ -1,5 +1,6 @@
 import gleam/http.{Header}
 import gleam/dynamic.{Dynamic}
+import gleam/erlang/atom.{Atom}
 import gleam/result
 import gleam/string_builder.{StringBuilder}
 import gleam/bit_builder.{BitBuilder}
@@ -15,14 +16,36 @@ pub type Frame {
   Binary(BitString)
 }
 
+pub type ConnectionOptsTransportOpts {
+  Verify(Atom)
+}
+
+pub type ConnectionOpts {
+  Transport(Atom)
+  TransportOpts(List(ConnectionOptsTransportOpts))
+}
+
 pub fn connect(
   hostname: String,
   path: String,
   on port: Int,
   with headers: List(Header),
 ) -> Result(Connection, ConnectError) {
+  let opts = []
+  connect_with_options(hostname, path, port, headers, opts)
+}
+
+pub fn connect_with_options(
+  hostname: String,
+  path: String,
+  on port: Int,
+  with headers: List(Header),
+  opts: List(ConnectionOpts),
+) {
+  let opts_map = map_from_list(opts)
+
   try pid =
-    gun.open(hostname, port)
+    gun.open(hostname, port, opts_map)
     |> result.map_error(ConnectionFailed)
   try _ =
     gun.await_up(pid)
@@ -63,6 +86,9 @@ pub external fn receive(from: Connection, within: Int) -> Result(Frame, Nil) =
 
 external fn await_upgrade(from: Connection, within: Int) -> Result(Nil, Dynamic) =
   "nerf_ffi" "ws_await_upgrade"
+
+pub external fn map_from_list(list: List(a)) -> m =
+  "maps" "from_list"
 
 // TODO: listen for close events
 pub fn close(conn: Connection) -> Nil {

--- a/src/nerf/websocket.gleam
+++ b/src/nerf/websocket.gleam
@@ -1,6 +1,5 @@
 import gleam/http.{Header}
 import gleam/dynamic.{Dynamic}
-import gleam/erlang/atom.{Atom}
 import gleam/result
 import gleam/string_builder.{StringBuilder}
 import gleam/bit_builder.{BitBuilder}
@@ -16,12 +15,21 @@ pub type Frame {
   Binary(BitString)
 }
 
+pub type ConnectionOptsTransport {
+  Tcp
+  Tls
+}
+
+pub type ConnectionOptsTransportOptsVerify {
+  VerifyNone
+}
+
 pub type ConnectionOptsTransportOpts {
-  Verify(Atom)
+  Verify(ConnectionOptsTransportOptsVerify)
 }
 
 pub type ConnectionOpts {
-  Transport(Atom)
+  Transport(ConnectionOptsTransport)
   TransportOpts(List(ConnectionOptsTransportOpts))
 }
 
@@ -87,7 +95,7 @@ pub external fn receive(from: Connection, within: Int) -> Result(Frame, Nil) =
 external fn await_upgrade(from: Connection, within: Int) -> Result(Nil, Dynamic) =
   "nerf_ffi" "ws_await_upgrade"
 
-pub external fn map_from_list(list: List(a)) -> m =
+external fn map_from_list(list: List(a)) -> m =
   "maps" "from_list"
 
 // TODO: listen for close events


### PR DESCRIPTION
Added a new function `connect_with_options` for the backwards compatibility. 

```gleam
  let opts = [
    websocket.Transport(atom.create_from_string("tls")),
    websocket.TransportOpts([websocket.Verify(atom.create_from_string("verify_none"))]),
  ]
  assert Ok(conn) = websocket.connect_with_options("example.com", "/ws", 443, [], opts)
```

Those are the options that I use and have tested to be working. Also didn't want to create too many new types, so using atoms partially. Should be easy to add more options later.