### PR TITLE
Update for gleam 0.29

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,15 @@ import gleam/erlang/atom
 
 pub fn main() {
   // Connect
-  assert Ok(conn) = websocket.connect("example.com", "/ws", 8080, [])
+  let assert Ok(conn) = websocket.connect("example.com", "/ws", 8080, [])
 
   // Send some messages
   websocket.send(conn, "Hello")
   websocket.send(conn, "World")
 
   // Receive some messages
-  assert Ok(Text("Hello")) = websocket.receive(conn, 500)
-  assert Ok(Text("World")) = websocket.receive(conn, 500)
+  let assert Ok(Text("Hello")) = websocket.receive(conn, 500)
+  let assert Ok(Text("World")) = websocket.receive(conn, 500)
 
   // Close the connection
   websocket.close(conn)

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,12 +1,12 @@
 name = "nerf"
-version = "0.3.1"
+version = "0.4.0"
 licences = ["Apache-2.0"]
 description = "Gleam bindings to gun, the HTTP/1.1, HTTP/2 and Websocket client"
 repository = { type = "github", user = "lpil", repo = "nerf" }
 links = [{ title = "Website", href = "https://gleam.run" }]
 
 [dependencies]
-gleam_stdlib = "~> 0.2"
+gleam_stdlib = "~> 0.24"
 gun = "> 1.3.0 and < 3.0.0"
 gleam_http = "~> 3.0"
 gleam_erlang = "~> 0.9"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,19 +2,19 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "certifi", version = "2.10.0", build_tools = ["rebar3"], requirements = [], otp_app = "certifi", source = "hex", outer_checksum = "E87A9DD6E7FE9C5804887850D4CDBCD83DB4DA7A27F928174F11E4E06FB7902E" },
-  { name = "cowlib", version = "2.7.3", build_tools = ["rebar3"], requirements = [], otp_app = "cowlib", source = "hex", outer_checksum = "1E1A3D176D52DAEBBECBBCDFD27C27726076567905C2A9D7398C54DA9D225761" },
-  { name = "gleam_erlang", version = "0.17.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "A3BB3D4A6AFC2E34CAB1A4960F0CBBC4AA1A052D5023477D16B848D86E69948A" },
-  { name = "gleam_http", version = "3.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "B66B7A1539CCB577119E4DC80DD3484C1A652CB032967954498EEDBAE3355763" },
-  { name = "gleam_stdlib", version = "0.24.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "BD0E75F3153375218E9EC380930E3621036CADCF4246AA55B193BDABFD06D5CE" },
-  { name = "gleeunit", version = "0.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "94DE5571BF62C416123C25F2C0F76E2AAF121F3416D156BFB72A588D0D03B8C6" },
-  { name = "gun", version = "1.3.3", build_tools = ["rebar3"], requirements = ["cowlib"], otp_app = "gun", source = "hex", outer_checksum = "3106CE167F9C9723F849E4FB54EA4A4D814E3996AE243A1C828B256E749041E0" },
+  { name = "certifi", version = "2.11.0", build_tools = ["rebar3"], requirements = [], otp_app = "certifi", source = "hex", outer_checksum = "9E37E0542EC3FABAA19A0734B3900DC095797FAC48C40A2A9741D8AD5E3C9BB7" },
+  { name = "cowlib", version = "2.12.1", build_tools = ["make", "rebar3"], requirements = [], otp_app = "cowlib", source = "hex", outer_checksum = "163B73F6367A7341B33C794C4E88E7DBFE6498AC42DCD69EF44C5BC5507C8DB0" },
+  { name = "gleam_erlang", version = "0.19.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "720D1E0A0CEBBD51C4AA88501D1D4FBFEF4AA7B3332C994691ED944767A52582" },
+  { name = "gleam_http", version = "3.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "D034F5CE0639CD142CBA210B7D5D14236C284B0C5772A043D2E22128594573AE" },
+  { name = "gleam_stdlib", version = "0.29.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "DB981FB670AAC6392C0694AF639C49ADF1C2E42664D5F90BBF573102667B8E53" },
+  { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
+  { name = "gun", version = "2.0.1", build_tools = ["make", "rebar3"], requirements = ["cowlib"], otp_app = "gun", source = "hex", outer_checksum = "A10BC8D6096B9502205022334F719CC9A08D9ADCFBFC0DBEE9EF31B56274A20B" },
 ]
 
 [requirements]
 certifi = "~> 2.8"
 gleam_erlang = "~> 0.9"
 gleam_http = "~> 3.0"
-gleam_stdlib = "~> 0.2"
+gleam_stdlib = "~> 0.24"
 gleeunit = "~> 0.6"
 gun = "> 1.3.0 and < 3.0.0"

--- a/src/nerf/websocket.gleam
+++ b/src/nerf/websocket.gleam
@@ -21,11 +21,11 @@ pub fn connect(
   on port: Int,
   with headers: List(Header),
 ) -> Result(Connection, ConnectError) {
-  use pid <- try(
+  use pid <- result.try(
     gun.open(hostname, port)
     |> result.map_error(ConnectionFailed),
   )
-  use _ <- try(
+  use _ <- result.try(
     gun.await_up(pid)
     |> result.map_error(ConnectionFailed),
   )
@@ -33,7 +33,7 @@ pub fn connect(
   // Upgrade to websockets
   let ref = gun.ws_upgrade(pid, path, headers)
   let conn = Connection(pid: pid, ref: ref)
-  use _ <- try(
+  use _ <- result.try(
     await_upgrade(conn, 1000)
     |> result.map_error(ConnectionFailed),
   )

--- a/src/nerf/websocket.gleam
+++ b/src/nerf/websocket.gleam
@@ -21,19 +21,19 @@ pub fn connect(
   on port: Int,
   with headers: List(Header),
 ) -> Result(Connection, ConnectError) {
-  try pid =
-    gun.open(hostname, port)
-    |> result.map_error(ConnectionFailed)
-  try _ =
-    gun.await_up(pid)
-    |> result.map_error(ConnectionFailed)
+  use pid =
+    try(gun.open(hostname, port)
+    |> result.map_error(ConnectionFailed))
+  use _ =
+    try(gun.await_up(pid)
+    |> result.map_error(ConnectionFailed))
 
   // Upgrade to websockets
   let ref = gun.ws_upgrade(pid, path, headers)
   let conn = Connection(pid: pid, ref: ref)
-  try _ =
-    await_upgrade(conn, 1000)
-    |> result.map_error(ConnectionFailed)
+  use _ =
+    try(await_upgrade(conn, 1000)
+    |> result.map_error(ConnectionFailed))
 
   // TODO: handle upgrade failure
   // https://ninenines.eu/docs/en/gun/2.0/guide/websocket/

--- a/src/nerf/websocket.gleam
+++ b/src/nerf/websocket.gleam
@@ -21,19 +21,22 @@ pub fn connect(
   on port: Int,
   with headers: List(Header),
 ) -> Result(Connection, ConnectError) {
-  use pid =
-    try(gun.open(hostname, port)
-    |> result.map_error(ConnectionFailed))
-  use _ =
-    try(gun.await_up(pid)
-    |> result.map_error(ConnectionFailed))
+  use pid <- try(
+    gun.open(hostname, port)
+    |> result.map_error(ConnectionFailed),
+  )
+  use _ <- try(
+    gun.await_up(pid)
+    |> result.map_error(ConnectionFailed),
+  )
 
   // Upgrade to websockets
   let ref = gun.ws_upgrade(pid, path, headers)
   let conn = Connection(pid: pid, ref: ref)
-  use _ =
-    try(await_upgrade(conn, 1000)
-    |> result.map_error(ConnectionFailed))
+  use _ <- try(
+    await_upgrade(conn, 1000)
+    |> result.map_error(ConnectionFailed),
+  )
 
   // TODO: handle upgrade failure
   // https://ninenines.eu/docs/en/gun/2.0/guide/websocket/

--- a/test/nerf_test.gleam
+++ b/test/nerf_test.gleam
@@ -10,27 +10,27 @@ pub fn main() {
 
 pub fn echo_test() {
   // Connect
-  assert Ok(conn) = websocket.connect("localhost", "/ws", 8080, [])
+  let assert Ok(conn) = websocket.connect("localhost", "/ws", 8080, [])
 
   // The server we're using sends a little hello message
-  assert Ok(Text(msg)) = websocket.receive(conn, 500)
-  assert True = string.starts_with(msg, "Request served by ")
+  let assert Ok(Text(msg)) = websocket.receive(conn, 500)
+  let assert True = string.starts_with(msg, "Request served by ")
 
   // Send some messages, the test server echos them back
   websocket.send(conn, "Hello")
   websocket.send(conn, "World")
-  assert Ok(Text("Hello")) = websocket.receive(conn, 500)
-  assert Ok(Text("World")) = websocket.receive(conn, 500)
+  let assert Ok(Text("Hello")) = websocket.receive(conn, 500)
+  let assert Ok(Text("World")) = websocket.receive(conn, 500)
 
   websocket.send_builder(conn, string_builder.from_string("Goodbye"))
   websocket.send_builder(conn, string_builder.from_string("Universe"))
-  assert Ok(Text("Goodbye")) = websocket.receive(conn, 500)
-  assert Ok(Text("Universe")) = websocket.receive(conn, 500)
+  let assert Ok(Text("Goodbye")) = websocket.receive(conn, 500)
+  let assert Ok(Text("Universe")) = websocket.receive(conn, 500)
 
   websocket.send_binary(conn, <<1, 2, 3, 4>>)
   websocket.send_binary(conn, <<5, 6, 7, 8>>)
-  assert Ok(Binary(<<1, 2, 3, 4>>)) = websocket.receive(conn, 500)
-  assert Ok(Binary(<<5, 6, 7, 8>>)) = websocket.receive(conn, 500)
+  let assert Ok(Binary(<<1, 2, 3, 4>>)) = websocket.receive(conn, 500)
+  let assert Ok(Binary(<<5, 6, 7, 8>>)) = websocket.receive(conn, 500)
 
   websocket.send_binary_builder(
     conn,
@@ -40,8 +40,8 @@ pub fn echo_test() {
     conn,
     bit_builder.from_bit_string(<<4, 3, 2, 1>>),
   )
-  assert Ok(Binary(<<8, 7, 6, 5>>)) = websocket.receive(conn, 500)
-  assert Ok(Binary(<<4, 3, 2, 1>>)) = websocket.receive(conn, 500)
+  let assert Ok(Binary(<<8, 7, 6, 5>>)) = websocket.receive(conn, 500)
+  let assert Ok(Binary(<<4, 3, 2, 1>>)) = websocket.receive(conn, 500)
 
   // Close the connection
   websocket.close(conn)
@@ -49,15 +49,15 @@ pub fn echo_test() {
 
 pub fn echo_wss_test() {
   // Connect
-  assert Ok(conn1) =
+  let assert Ok(conn1) =
     websocket.connect("socketsbay.com", "/wss/v2/2/demo/", 443, [])
-  assert Ok(conn2) =
+  let assert Ok(conn2) =
     websocket.connect("socketsbay.com", "/wss/v2/2/demo/", 443, [])
 
   websocket.send(conn1, "Hello")
   websocket.send(conn2, "World")
-  assert Ok(Text("World")) = websocket.receive(conn1, 500)
-  assert Ok(Text("Hello")) = websocket.receive(conn2, 500)
+  let assert Ok(Text("World")) = websocket.receive(conn1, 500)
+  let assert Ok(Text("Hello")) = websocket.receive(conn2, 500)
 
   // Close the connection
   websocket.close(conn1)


### PR DESCRIPTION
Tried to update this for 0.29. I ran the tests but they came back as cancelled, and I didn't want to try and downgrade gleam to test this previous to 0.29. 

- Updated `try` to `use` and `result.try` function
- Updated `stdlib` to `0.24` or had another error about try. 
- Bumped to `0.4.0` due to version changes. 