### PR TITLE
fixes for gleam 0.33

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -6,11 +6,11 @@ repository = { type = "github", user = "lpil", repo = "nerf" }
 links = [{ title = "Website", href = "https://gleam.run" }]
 
 [dependencies]
-gleam_stdlib = "~> 0.34"
+gleam_stdlib = "~> 0.36"
 gun = "> 1.3.0 and < 3.0.0"
-gleam_http = "~> 3.5"
-gleam_erlang = "~> 0.23"
-certifi = "~> 2.8"
+gleam_http = "~> 3.6"
+certifi = "~> 2.13"
+gleam_erlang = "~> 0.24"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/gleam.toml
+++ b/gleam.toml
@@ -6,11 +6,11 @@ repository = { type = "github", user = "lpil", repo = "nerf" }
 links = [{ title = "Website", href = "https://gleam.run" }]
 
 [dependencies]
-gleam_stdlib = "~> 0.24"
+gleam_stdlib = "~> 0.34"
 gun = "> 1.3.0 and < 3.0.0"
-gleam_http = "~> 3.0"
-gleam_erlang = "~> 0.9"
+gleam_http = "~> 3.5"
+gleam_erlang = "~> 0.23"
 certifi = "~> 2.8"
 
 [dev-dependencies]
-gleeunit = "~> 0.6"
+gleeunit = "~> 1.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,19 +2,19 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "certifi", version = "2.11.0", build_tools = ["rebar3"], requirements = [], otp_app = "certifi", source = "hex", outer_checksum = "9E37E0542EC3FABAA19A0734B3900DC095797FAC48C40A2A9741D8AD5E3C9BB7" },
+  { name = "certifi", version = "2.12.0", build_tools = ["rebar3"], requirements = [], otp_app = "certifi", source = "hex", outer_checksum = "EE68D85DF22E554040CDB4BE100F33873AC6051387BAF6A8F6CE82272340FF1C" },
   { name = "cowlib", version = "2.12.1", build_tools = ["make", "rebar3"], requirements = [], otp_app = "cowlib", source = "hex", outer_checksum = "163B73F6367A7341B33C794C4E88E7DBFE6498AC42DCD69EF44C5BC5507C8DB0" },
-  { name = "gleam_erlang", version = "0.19.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "720D1E0A0CEBBD51C4AA88501D1D4FBFEF4AA7B3332C994691ED944767A52582" },
-  { name = "gleam_http", version = "3.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "D034F5CE0639CD142CBA210B7D5D14236C284B0C5772A043D2E22128594573AE" },
-  { name = "gleam_stdlib", version = "0.29.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "DB981FB670AAC6392C0694AF639C49ADF1C2E42664D5F90BBF573102667B8E53" },
-  { name = "gleeunit", version = "0.10.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "ECEA2DE4BE6528D36AFE74F42A21CDF99966EC36D7F25DEB34D47DD0F7977BAF" },
+  { name = "gleam_erlang", version = "0.23.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "C21CFB816C114784E669FFF4BBF433535EEA9960FA2F216209B8691E87156B96" },
+  { name = "gleam_http", version = "3.5.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "AECDA43AFD523D07A8F09068598A6E271C505278A0CB6F9C7A2E4365EAE8D11E" },
+  { name = "gleam_stdlib", version = "0.34.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "1FB8454D2991E9B4C0C804544D8A9AD0F6184725E20D63C3155F0AEB4230B016" },
+  { name = "gleeunit", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D364C87AFEB26BDB4FB8A5ABDE67D635DC9FA52D6AB68416044C35B096C6882D" },
   { name = "gun", version = "2.0.1", build_tools = ["make", "rebar3"], requirements = ["cowlib"], otp_app = "gun", source = "hex", outer_checksum = "A10BC8D6096B9502205022334F719CC9A08D9ADCFBFC0DBEE9EF31B56274A20B" },
 ]
 
 [requirements]
-certifi = "~> 2.8"
-gleam_erlang = "~> 0.9"
-gleam_http = "~> 3.0"
-gleam_stdlib = "~> 0.24"
-gleeunit = "~> 0.6"
-gun = "> 1.3.0 and < 3.0.0"
+certifi = { version = "~> 2.8" }
+gleam_erlang = { version = "~> 0.23" }
+gleam_http = { version = "~> 3.5" }
+gleam_stdlib = { version = "~> 0.34" }
+gleeunit = { version = "~> 1.0" }
+gun = { version = "> 1.3.0 and < 3.0.0" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,19 +2,19 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "certifi", version = "2.12.0", build_tools = ["rebar3"], requirements = [], otp_app = "certifi", source = "hex", outer_checksum = "EE68D85DF22E554040CDB4BE100F33873AC6051387BAF6A8F6CE82272340FF1C" },
-  { name = "cowlib", version = "2.12.1", build_tools = ["make", "rebar3"], requirements = [], otp_app = "cowlib", source = "hex", outer_checksum = "163B73F6367A7341B33C794C4E88E7DBFE6498AC42DCD69EF44C5BC5507C8DB0" },
-  { name = "gleam_erlang", version = "0.23.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "C21CFB816C114784E669FFF4BBF433535EEA9960FA2F216209B8691E87156B96" },
-  { name = "gleam_http", version = "3.5.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "AECDA43AFD523D07A8F09068598A6E271C505278A0CB6F9C7A2E4365EAE8D11E" },
-  { name = "gleam_stdlib", version = "0.34.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "1FB8454D2991E9B4C0C804544D8A9AD0F6184725E20D63C3155F0AEB4230B016" },
+  { name = "certifi", version = "2.13.0", build_tools = ["rebar3"], requirements = [], otp_app = "certifi", source = "hex", outer_checksum = "8F3D9533A0F06070AFDFD5D596B32E21C6580667A492891851B0E2737BC507A1" },
+  { name = "cowlib", version = "2.13.0", build_tools = ["make", "rebar3"], requirements = [], otp_app = "cowlib", source = "hex", outer_checksum = "E1E1284DC3FC030A64B1AD0D8382AE7E99DA46C3246B815318A4B848873800A4" },
+  { name = "gleam_erlang", version = "0.24.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "26BDB52E61889F56A291CB34167315780EE4AA20961917314446542C90D1C1A0" },
+  { name = "gleam_http", version = "3.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "8C07DF9DF8CC7F054C650839A51C30A7D3C26482AC241C899C1CEA86B22DBE51" },
+  { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
   { name = "gleeunit", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D364C87AFEB26BDB4FB8A5ABDE67D635DC9FA52D6AB68416044C35B096C6882D" },
-  { name = "gun", version = "2.0.1", build_tools = ["make", "rebar3"], requirements = ["cowlib"], otp_app = "gun", source = "hex", outer_checksum = "A10BC8D6096B9502205022334F719CC9A08D9ADCFBFC0DBEE9EF31B56274A20B" },
+  { name = "gun", version = "2.1.0", build_tools = ["make", "rebar3"], requirements = ["cowlib"], otp_app = "gun", source = "hex", outer_checksum = "52FC7FC246BFC3B00E01AEA1C2854C70A366348574AB50C57DFE796D24A0101D" },
 ]
 
 [requirements]
-certifi = { version = "~> 2.8" }
-gleam_erlang = { version = "~> 0.23" }
-gleam_http = { version = "~> 3.5" }
-gleam_stdlib = { version = "~> 0.34" }
+certifi = { version = "~> 2.13" }
+gleam_erlang = { version = "~> 0.24" }
+gleam_http = { version = "~> 3.6" }
+gleam_stdlib = { version = "~> 0.36"}
 gleeunit = { version = "~> 1.0" }
 gun = { version = "> 1.3.0 and < 3.0.0" }

--- a/src/nerf/gun.gleam
+++ b/src/nerf/gun.gleam
@@ -35,13 +35,3 @@ pub type Frame {
   TextBuilder(StringBuilder)
   BinaryBuilder(BitBuilder)
 }
-
-type OkAtom
-
-@external(erlang, "nerf_ffi", "ws_send_erl")
-fn ws_send_erl(conn: ConnectionPid, frame: Frame) -> OkAtom
-
-pub fn ws_send(pid: ConnectionPid, frame: Frame) -> Nil {
-  ws_send_erl(pid, frame)
-  Nil
-}

--- a/src/nerf/gun.gleam
+++ b/src/nerf/gun.gleam
@@ -1,45 +1,45 @@
 //// Low level bindings to the gun API. You typically do not need to use this.
 //// Prefer the other modules in this library.
 
-import gleam/http.{Header}
-import gleam/erlang/charlist.{Charlist}
-import gleam/dynamic.{Dynamic}
-import gleam/string_builder.{StringBuilder}
-import gleam/bit_builder.{BitBuilder}
+import gleam/http.{type Header}
+import gleam/erlang/charlist.{type Charlist}
+import gleam/dynamic.{type Dynamic}
+import gleam/string_builder.{type StringBuilder}
+import gleam/bit_builder.{type BitBuilder}
 
-pub external type StreamReference
+pub opaque type StreamReference
 
-pub external type ConnectionPid
+pub opaque type ConnectionPid
 
 pub fn open(host: String, port: Int) -> Result(ConnectionPid, Dynamic) {
   open_erl(charlist.from_string(host), port)
 }
 
-pub external fn open_erl(Charlist, Int) -> Result(ConnectionPid, Dynamic) =
-  "gun" "open"
+@external(erlang, "gun", "open")
+pub fn open_erl(host: Charlist, port: Int) -> Result(ConnectionPid, Dynamic)
 
-pub external fn await_up(ConnectionPid) -> Result(Dynamic, Dynamic) =
-  "gun" "await_up"
+@external(erlang, "gun", "await_up")
+pub fn await_up(conn: ConnectionPid) -> Result(Dynamic, Dynamic)
 
-pub external fn ws_upgrade(
-  ConnectionPid,
-  String,
-  List(Header),
-) -> StreamReference =
-  "gun" "ws_upgrade"
+@external(erlang, "gun", "ws_upgrade")
+pub fn ws_upgrade(
+  conn: ConnectionPid,
+  path: String,
+  headers: List(Header),
+) -> StreamReference
 
 pub type Frame {
   Close
   Text(String)
-  Binary(BitString)
+  Binary(BitArray)
   TextBuilder(StringBuilder)
   BinaryBuilder(BitBuilder)
 }
 
-external type OkAtom
+type OkAtom
 
-external fn ws_send_erl(ConnectionPid, Frame) -> OkAtom =
-  "nerf_ffi" "ws_send_erl"
+@external(erlang, "nerf_ffi", "ws_send_erl")
+fn ws_send_erl(conn: ConnectionPid, frame: Frame) -> OkAtom
 
 pub fn ws_send(pid: ConnectionPid, frame: Frame) -> Nil {
   ws_send_erl(pid, frame)

--- a/src/nerf/gun.gleam
+++ b/src/nerf/gun.gleam
@@ -5,7 +5,7 @@ import gleam/http.{type Header}
 import gleam/erlang/charlist.{type Charlist}
 import gleam/dynamic.{type Dynamic}
 import gleam/string_builder.{type StringBuilder}
-import gleam/bit_builder.{type BitBuilder}
+import gleam/bytes_builder.{type BytesBuilder}
 
 pub opaque type StreamReference
 
@@ -33,5 +33,5 @@ pub type Frame {
   Text(String)
   Binary(BitArray)
   TextBuilder(StringBuilder)
-  BinaryBuilder(BitBuilder)
+  BinaryBuilder(BytesBuilder)
 }

--- a/src/nerf/websocket.gleam
+++ b/src/nerf/websocket.gleam
@@ -1,9 +1,9 @@
-import gleam/http.{Header}
-import gleam/dynamic.{Dynamic}
+import gleam/http.{type Header}
+import gleam/dynamic.{type Dynamic}
 import gleam/result
-import gleam/string_builder.{StringBuilder}
-import gleam/bit_builder.{BitBuilder}
-import nerf/gun.{ConnectionPid, StreamReference}
+import gleam/string_builder.{type StringBuilder}
+import gleam/bit_builder.{type BitBuilder}
+import nerf/gun.{type ConnectionPid, type StreamReference}
 
 pub opaque type Connection {
   Connection(ref: StreamReference, pid: ConnectionPid)
@@ -12,7 +12,7 @@ pub opaque type Connection {
 pub type Frame {
   Close
   Text(String)
-  Binary(BitString)
+  Binary(BitArray)
 }
 
 pub fn connect(
@@ -53,7 +53,7 @@ pub fn send_builder(to conn: Connection, this message: StringBuilder) -> Nil {
   gun.ws_send(conn.pid, gun.TextBuilder(message))
 }
 
-pub fn send_binary(to conn: Connection, this message: BitString) -> Nil {
+pub fn send_binary(to conn: Connection, this message: BitArray) -> Nil {
   gun.ws_send(conn.pid, gun.Binary(message))
 }
 
@@ -61,11 +61,11 @@ pub fn send_binary_builder(to conn: Connection, this message: BitBuilder) -> Nil
   gun.ws_send(conn.pid, gun.BinaryBuilder(message))
 }
 
-pub external fn receive(from: Connection, within: Int) -> Result(Frame, Nil) =
-  "nerf_ffi" "ws_receive"
+@external(erlang, "nerf_ffi", "ws_receive")
+pub fn receive(from: Connection, within: Int) -> Result(Frame, Nil)
 
-external fn await_upgrade(from: Connection, within: Int) -> Result(Nil, Dynamic) =
-  "nerf_ffi" "ws_await_upgrade"
+@external(erlang, "nerf_ffi", "ws_await_upgrade")
+fn await_upgrade(from: Connection, within: Int) -> Result(Nil, Dynamic)
 
 // TODO: listen for close events
 pub fn close(conn: Connection) -> Nil {

--- a/src/nerf/websocket.gleam
+++ b/src/nerf/websocket.gleam
@@ -2,7 +2,7 @@ import gleam/http.{type Header}
 import gleam/dynamic.{type Dynamic}
 import gleam/result
 import gleam/string_builder.{type StringBuilder}
-import gleam/bit_builder.{type BitBuilder}
+import gleam/bytes_builder.{type BytesBuilder}
 import nerf/gun.{type ConnectionPid, type StreamReference}
 
 pub opaque type Connection {
@@ -51,7 +51,7 @@ pub fn send_binary(to conn: Connection, this message: BitArray) -> Nil {
   ws_send(conn, gun.Binary(message))
 }
 
-pub fn send_binary_builder(to conn: Connection, this message: BitBuilder) -> Nil {
+pub fn send_binary_builder(to conn: Connection, this message: BytesBuilder) -> Nil {
   ws_send(conn, gun.BinaryBuilder(message))
 }
 

--- a/src/nerf_ffi.erl
+++ b/src/nerf_ffi.erl
@@ -34,10 +34,10 @@ ws_await_upgrade({connection, Ref, Pid}, Timeout)
         exit(timeout)
     end.
 
-ws_send_erl(Pid, {text_builder, Text}) ->
-    ws_send_erl(Pid, {text, Text});
-ws_send_erl(Pid, {binary_builder, Bin}) ->
-    ws_send_erl(Pid, {binary, Bin});
-ws_send_erl(Pid, Frame) ->
-    gun:ws_send(Pid, Frame).
+ws_send_erl({connection, Ref, Pid}, {text_builder, Text}) ->
+    ws_send_erl({connection, Ref, Pid}, {text, Text});
+ws_send_erl({connection, Ref, Pid}, {binary_builder, Bin}) ->
+    ws_send_erl({connection, Ref, Pid}, {binary, Bin});
+ws_send_erl({connection, Ref, Pid}, Frame) ->
+    gun:ws_send(Pid, Ref, Frame).
 

--- a/test/nerf_test.gleam
+++ b/test/nerf_test.gleam
@@ -2,7 +2,8 @@ import gleam/string
 import gleam/string_builder
 import gleam/bytes_builder
 import gleeunit
-import nerf/websocket.{Binary, Text}
+import nerf/gun.{Binary, Text}
+import nerf/websocket
 
 pub fn main() {
   gleeunit.main()

--- a/test/nerf_test.gleam
+++ b/test/nerf_test.gleam
@@ -1,6 +1,6 @@
 import gleam/string
 import gleam/string_builder
-import gleam/bit_builder
+import gleam/bytes_builder
 import gleeunit
 import nerf/websocket.{Binary, Text}
 
@@ -34,11 +34,11 @@ pub fn echo_test() {
 
   websocket.send_binary_builder(
     conn,
-    bit_builder.from_bit_string(<<8, 7, 6, 5>>),
+    bytes_builder.from_bit_array(<<8, 7, 6, 5>>),
   )
   websocket.send_binary_builder(
     conn,
-    bit_builder.from_bit_string(<<4, 3, 2, 1>>),
+    bytes_builder.from_bit_array(<<4, 3, 2, 1>>),
   )
   let assert Ok(Binary(<<8, 7, 6, 5>>)) = websocket.receive(conn, 500)
   let assert Ok(Binary(<<4, 3, 2, 1>>)) = websocket.receive(conn, 500)


### PR DESCRIPTION
syntax changes to update to latest Gleam
- import types with import a/b.{type C}
- pub external type -> pub opaque type
- BitString -> BitArray
- pub external fn -> @external(erlang, …

- update dependencies, especially gleeunit 0.10 was incompatible with gleam 0.33